### PR TITLE
docs: add metrics module docstring

### DIFF
--- a/genomevault/api/routers/metrics.py
+++ b/genomevault/api/routers/metrics.py
@@ -1,7 +1,4 @@
-"""
-Prometheus metrics endpoint for monitoring.
-
-"""
+"""Prometheus metrics endpoint for monitoring."""
 
 from typing import Any
 


### PR DESCRIPTION
## Summary
- add module docstring to metrics router

## Testing
- `ruff check genomevault/api/routers/metrics.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'cryptography')*

------
https://chatgpt.com/codex/tasks/task_e_689e1f416b4c832d801458cb20dfe316