### PR TITLE
Validate metric and dtype compatibility for hypervector index

### DIFF
--- a/tests/hv/test_index_metric_dtype.py
+++ b/tests/hv/test_index_metric_dtype.py
@@ -1,0 +1,77 @@
+import numpy as np
+import pytest
+from genomevault.hypervector.index import build, search, load_index_metadata
+
+
+def test_build_defaults_metric_based_on_dtype(tmp_path):
+    """Building infers metric from vector dtype."""
+    float_vecs = [
+        np.array([0.1, 0.2, 0.3], dtype=np.float32),
+        np.array([0.2, 0.1, 0.4], dtype=np.float32),
+    ]
+    build(float_vecs, ["a", "b"], tmp_path)
+    manifest = load_index_metadata(tmp_path)
+    assert manifest["metric"] == "cosine"
+
+    binary_vecs = [
+        np.array([0, 1, 0], dtype=np.uint8),
+        np.array([1, 0, 1], dtype=np.uint8),
+    ]
+    build(binary_vecs, ["c", "d"], tmp_path / "bin")
+    manifest_bin = load_index_metadata(tmp_path / "bin")
+    assert manifest_bin["metric"] == "hamming"
+
+
+def test_build_rejects_mismatched_metric(tmp_path):
+    """Invalid metric-dtype pairs raise errors during build."""
+    float_vecs = [
+        np.array([0.1, 0.2], dtype=np.float32),
+        np.array([0.2, 0.3], dtype=np.float32),
+    ]
+    with pytest.raises(ValueError):
+        build(float_vecs, ["a", "b"], tmp_path, metric="hamming")
+
+    binary_vecs = [
+        np.array([0, 1], dtype=np.uint8),
+        np.array([1, 0], dtype=np.uint8),
+    ]
+    with pytest.raises(ValueError):
+        build(binary_vecs, ["a", "b"], tmp_path / "b", metric="cosine")
+
+
+def test_search_rejects_mismatched_query_dtype(tmp_path):
+    """Search validates query dtype against index metric."""
+    binary_vecs = [
+        np.array([0, 1, 0], dtype=np.uint8),
+        np.array([1, 0, 1], dtype=np.uint8),
+    ]
+    build(binary_vecs, ["a", "b"], tmp_path, metric="hamming")
+    with pytest.raises(ValueError):
+        search(np.array([0.1, 0.2, 0.3], dtype=np.float32), tmp_path)
+
+    float_vecs = [
+        np.array([0.1, 0.2, 0.3], dtype=np.float32),
+        np.array([0.2, 0.1, 0.4], dtype=np.float32),
+    ]
+    build(float_vecs, ["c", "d"], tmp_path / "f", metric="cosine")
+    with pytest.raises(ValueError):
+        search(np.array([0, 1, 0], dtype=np.uint8), tmp_path / "f")
+
+
+def test_search_allows_valid_query(tmp_path):
+    """Valid metric and dtype combinations search successfully."""
+    binary_vecs = [
+        np.array([0, 1, 0], dtype=np.uint8),
+        np.array([1, 0, 1], dtype=np.uint8),
+    ]
+    build(binary_vecs, ["a", "b"], tmp_path / "h", metric="hamming")
+    res = search(np.array([0, 1, 0], dtype=np.uint8), tmp_path / "h")
+    assert res and {r["id"] for r in res} <= {"a", "b"}
+
+    float_vecs = [
+        np.array([0.1, 0.2, 0.3], dtype=np.float32),
+        np.array([0.2, 0.1, 0.4], dtype=np.float32),
+    ]
+    build(float_vecs, ["c", "d"], tmp_path / "c", metric="cosine")
+    res = search(np.array([0.1, 0.2, 0.3], dtype=np.float32), tmp_path / "c")
+    assert res and {r["id"] for r in res} <= {"c", "d"}


### PR DESCRIPTION
## Summary
- ensure hypervector search helpers validate vector dtype against chosen metric
- infer metric from vector dtype when building indexes
- test valid and invalid metric/dtype combinations

## Testing
- `ruff check .` (fails: Found 1628 errors)
- `pytest tests/hv/test_index_metric_dtype.py`


------
https://chatgpt.com/codex/tasks/task_e_689e3e54943c832d865945a5cc0efd99
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added checks to ensure metric and vector dtype compatibility when building and searching hypervector indexes, preventing invalid combinations and inferring metric when not specified.

- **Bug Fixes**
 - Validates that vector dtypes match the selected metric for hamming, cosine, or euclidean.
 - Raises clear errors for invalid metric-dtype pairs during build and search.
 - Infers metric from vector dtype if metric is not provided.

<!-- End of auto-generated description by cubic. -->

